### PR TITLE
Optimized autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,7 @@
 # Run this to generate all the initial makefiles, etc.
 
 srcdir=$(dirname "$0")
-test -z "$srcdir" && srcdir=.
+case "$srcdir" in ('') srcdir=.; esac
 
 if [ ! -f $srcdir/configure.ac ]; then
   echo "**Error**: Directory "\'$srcdir\'" does not look like the top-level" \
@@ -13,27 +13,27 @@ fi
 
 PKG_NAME=$(autoconf --trace 'AC_INIT:$1' "$srcdir/configure.ac")
 
-if [ "$#" = 0 ] && [ -z "$NOCONFIGURE" ]; then
+case "$# ${#NOCONFIGURE}" in (0 0)
   echo "**Warning**: I am going to run 'configure' with no arguments." >&2
   echo "If you wish to pass any to it, please specify them on the '$0'" \
        "command line." >&2
-fi
+esac
 
 set -x
 aclocal --install || exit 1
 autoreconf --verbose --force --install -Wno-portability || exit 1
 { set +x; } 2>/dev/null
 
-if [ -z "$NOCONFIGURE" ]; then
+case "$NOCONFIGURE" in ('')
   set -x
   $srcdir/configure "$@" || exit 1
   { set +x; } 2>/dev/null
 
-  if [ "$1" = "--help" ]; then
+  case "$1" in (--help)
     exit 0
-  else
+  ;;(*)
     echo "Now type 'make' to compile $PKG_NAME." || exit 1
-  fi
-else
+  ;;esac
+;;(*)
   echo "Skipping configure process."
-fi
+;;esac


### PR DESCRIPTION
Just use case statements instead of calling test -z or test =; while test command is not always a built-in, case statement is so everywhere. Also you can prefix left-parenthesis to pattern with right-parenthesis.